### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/bfontaine/Graphs.rb.png)](https://travis-ci.org/bfontaine/Graphs.rb)
 [![Gem Version](https://badge.fury.io/rb/graphs.png)](http://badge.fury.io/rb/graphs)
 [![Coverage Status](https://coveralls.io/repos/bfontaine/Graphs.rb/badge.png)](https://coveralls.io/r/bfontaine/Graphs.rb)
-[![Inline docs](http://inch-pages.github.io/github/bfontaine/Graphs.rb.png)](http://inch-pages.github.io/github/bfontaine/Graphs.rb)
+[![Inline docs](http://inch-ci.org/github/bfontaine/Graphs.rb.png)](http://inch-ci.org/github/bfontaine/Graphs.rb)
 [![Dependency Status](https://gemnasium.com/bfontaine/Graphs.rb.png)](https://gemnasium.com/bfontaine/Graphs.rb)
 
 This library allows you to perform some basic operations on graphs, with


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
